### PR TITLE
feat(keys-and): ability to compare nested list objects

### DIFF
--- a/can-query-logic-test.js
+++ b/can-query-logic-test.js
@@ -162,6 +162,37 @@ QUnit.test("filterMembers basics", function(assert) {
 	]);
 });
 
+QUnit.test("filterMembers nested", function(assert) {
+    var subset = algebra.filterMembers(
+        { filter: { 'employees': {name: 'Patrick' } }},
+        [{
+            projectId: 1,
+            employees: [{
+                name: 'Patrick',
+            },
+            {
+                name: 'Justin',
+            }]
+        }, {
+            projectId: 2,
+            employees: [
+            {
+                name: 'Justin',
+            }]
+        }],
+    );
+
+    assert.deepEqual(subset, [{
+        projectId: 1,
+        employees: [{
+            name: 'Patrick',
+        },
+        {
+            name: 'Justin',
+        }]
+    }])
+})
+
 
 QUnit.test("unionMembers basics", function(assert) {
 	var union = algebra.unionMembers({

--- a/src/types/keys-and.js
+++ b/src/types/keys-and.js
@@ -23,23 +23,30 @@ var isMemberSymbol = canSymbol.for("can.isMember");
 
 
 KeysAnd.prototype.isMember = function(props, root, rootKey) {
-	var equal = true;
-	var preKey = rootKey ? rootKey + "." : "";
-	canReflect.eachKey(this.values, function(value, key) {
-		var isMember = value && (value[isMemberSymbol] || value.isMember);
-		if (isMember) {
-			if (!isMember.call(value, canGet(props, key), root || props, preKey + key)) {
-				equal = false;
-			}
-		} else {
-			if (value !== canGet(props, key)) {
-				equal = false;
-			}
-		}
-	});
-	return equal;
-};
+    var equal = true;
+    var preKey = rootKey ? rootKey + "." : "";
+    canReflect.eachKey(this.values, function(value, key) {
+        var isMember = value && (value[isMemberSymbol] || value.isMember);
+        if (isMember) {
+            if(canReflect.isListLike(props)) {
+                var match = false;
+                canReflect.each(props, (objInList) => {
+                    if(match) return;
 
+                    match = isMember.call(value, canGet(objInList, key), root || props, preKey + key)
+                })
+                equal = match;
+            } else if (!isMember.call(value, canGet(props, key), root || props, preKey + key)) {
+                equal = false;
+            }
+        } else {
+            if (value !== canGet(props, key)) {
+                equal = false;
+            }
+        }
+    });
+    return equal;
+};
 
 // ====== DEFINE COMPARISONS ========
 


### PR DESCRIPTION
This allows to run operations against nested object lists.

e.g.:
``` 
var subset = algebra.filterMembers(
        { filter: { 'employees': {name: 'Patrick' } }},
        [{
            projectId: 1,
            employees: [{
                name: 'Patrick',
            },
            {
                name: 'Justin',
            }]
        }, {
            projectId: 2,
            employees: [
            {
                name: 'Justin',
            }]
        }],
    );

    assert.deepEqual(subset, [{
        projectId: 1,
        employees: [{
            name: 'Patrick',
        },
        {
            name: 'Justin',
        }]
    }])
```